### PR TITLE
Fix version compare for custom version install

### DIFF
--- a/tasks/install/index.js
+++ b/tasks/install/index.js
@@ -84,7 +84,7 @@ function findLatestSdkVersion(channel, arch, version) {
         if (version.toLowerCase() !== 'latest') {
             // fetch custom version
             version = task.getInput('customVersion', false);
-            current = json.releases.find((item) => item.channel == channel && version == version);
+            current = json.releases.find((item) => item.channel == channel && uniformizeVersion(item.version) == uniformizeVersion(version));
         }
         task.debug(`Found version hash '${current.hash}'`);
         return {
@@ -92,6 +92,13 @@ function findLatestSdkVersion(channel, arch, version) {
             downloadUrl: json.base_url + '/' + current.archive,
         };
     });
+}
+// Removes the 'v' prefix from given version.
+function uniformizeVersion(version) {
+    if (version.startsWith('v')) {
+        return version.substring(1);
+    }
+    return version;
 }
 main().catch(error => {
     task.setResult(task.TaskResult.Failed, error);

--- a/tasks/install/index.ts
+++ b/tasks/install/index.ts
@@ -86,7 +86,7 @@ async function findLatestSdkVersion(channel: string, arch: string, version: stri
 	if (version.toLowerCase() !== 'latest') {
 		// fetch custom version
 		version = task.getInput('customVersion', false);
-		current = json.releases.find((item) => item.channel == channel && version == version);
+		current = json.releases.find((item) => item.channel == channel && uniformizeVersion(item.version) == uniformizeVersion(version));
 	}
 
 	task.debug(`Found version hash '${current.hash}'`);
@@ -94,6 +94,14 @@ async function findLatestSdkVersion(channel: string, arch: string, version: stri
 		version: current.version + '-' + channel,
 		downloadUrl: json.base_url + '/' + current.archive,
 	};
+}
+
+// Removes the 'v' prefix from given version.
+function uniformizeVersion(version) {
+    if (version.startsWith('v')) {
+        return version.substring(1);
+    }
+    return version;
 }
 
 main().catch(error => {


### PR DESCRIPTION
Installing custom version fails since it compares two same thing and will always get latest version.

Added `uniformizeVersion` to prevent confusion in entering version number (taken from alois' repo)