### PR TITLE
Add toggle for code coverage report

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Launch tests and publish a report as build test results.
 * _(Optional)_. Set `Test plain name` as a plain-text substring of the names of tests to run.
 * _(Optional)_. Set `Test plain name` as a plain-text substring of the names of tests to run.
 * _(Optional)_. Set `update goldens`: whether `matchesGoldenFile()` calls within your test methods should update the golden files rather than test for an existing match.
+* _(Optional)_. Set `Generate code coverage report`: whether flutter should generate a code coverage report based on tests in project. File is generated at `project source directory` in `coverage/lcov.info`.
 * _(Optional)_. The number of `concurrent` test processes to run. (defaults to `6`)
 
 ### Analyze

--- a/tasks/test/index.ts
+++ b/tasks/test/index.ts
@@ -25,9 +25,10 @@ async function main(): Promise<void> {
     let updateGoldens = task.getBoolInput('updateGoldens', false);
     let concurrency = task.getInput('concurrency', false);
     let canPublishTests = task.getInput('publishTests', false);
+    let canGenerateCodeCoverage = task.getInput("generateCodeCoverageReport", false);
 
     // 5. Running tests
-    var results = await runTests(flutterPath, (concurrency ? Number(concurrency) : null), updateGoldens, testName, testPlainName);
+    var results = await runTests(flutterPath, (concurrency ? Number(concurrency) : null), updateGoldens, testName, testPlainName, canGenerateCodeCoverage);
 
     // 6. Publishing tests
     if (canPublishTests) {
@@ -58,12 +59,16 @@ async function publishTests(results: any) {
     publisher.publish([xmlPath], false, "", "", "", true, "VSTS - Flutter");
 }
 
-async function runTests(flutter: string, concurrency?: number, updateGoldens?: boolean, name?: string, plainName?: string) {
+async function runTests(flutter: string, concurrency?: number, updateGoldens?: boolean, name?: string, plainName?: string, canGenerateCodeCoverage?: boolean) {
     let testRunner = task.tool(flutter);
     testRunner.arg(['test', '--pub']);
 
     if (updateGoldens) {
         testRunner.arg("--update-goldens");
+    }
+
+    if(canGenerateCodeCoverage) {
+        testRunner.arg("--coverage");
     }
 
     if (name) {

--- a/tasks/test/task.json
+++ b/tasks/test/task.json
@@ -46,6 +46,14 @@
             "helpMarkDown": "Whether matchesGoldenFile() calls within your test methods should update the golden files rather than test for an existing match."
         },
         {
+            "name": "generateCodeCoverageReport",
+            "type": "boolean",
+            "label": "Generate code coverage report",
+            "defaultValue": false,
+            "required": false,
+            "helpMarkDown": "Whether flutter should generate a code coverage report based on tests in project."
+        },
+        {
             "name": "concurrency",
             "type": "string",
             "label": "Concurrency",


### PR DESCRIPTION
Add the ability to run the `--coverage` option for flutter tests. This allows anyone to use this information for code coverage gates or other processes.