### PR TITLE
Add dart-define to aab

### DIFF
--- a/tasks/build/index.js
+++ b/tasks/build/index.js
@@ -56,7 +56,7 @@ function main() {
         if (target === "all"
             || target === "mobile"
             || target === "aab") {
-            yield buildAab(flutterPath, buildName, buildNumber, debugMode, buildFlavour, entryPoint, isVerbose, extraArgs);
+            yield buildAab(flutterPath, buildName, buildNumber, debugMode, buildFlavour, entryPoint, dartDefine, isVerbose, extraArgs);
         }
         if (target === "all" || target === "web") {
             yield buildWeb(flutterPath, isVerbose, extraArgs);
@@ -121,7 +121,7 @@ function buildApk(flutter, targetPlatform, buildName, buildNumber, debugMode, bu
         }
     });
 }
-function buildAab(flutter, buildName, buildNumber, debugMode, buildFlavour, entryPoint, isVerbose, extraArgs) {
+function buildAab(flutter, buildName, buildNumber, debugMode, buildFlavour, entryPoint, dartDefine, isVerbose, extraArgs) {
     return __awaiter(this, void 0, void 0, function* () {
         var args = [
             "build",
@@ -141,6 +141,9 @@ function buildAab(flutter, buildName, buildNumber, debugMode, buildFlavour, entr
         }
         if (entryPoint) {
             args.push("--target=" + entryPoint);
+        }
+        if (dartDefine) {
+            args.push("--dart-define=" + dartDefine);
         }
         if (isVerbose) {
             args.push("--verbose");

--- a/tasks/build/index.ts
+++ b/tasks/build/index.ts
@@ -81,6 +81,7 @@ async function main(): Promise<void> {
             debugMode,
             buildFlavour,
             entryPoint,
+            dartDefine,
             isVerbose,
             extraArgs);
     }
@@ -182,6 +183,7 @@ async function buildAab(
     debugMode?: boolean,
     buildFlavour?: string,
     entryPoint?: string,
+    dartDefine?: string,
     isVerbose?: boolean,
     extraArgs?: string) {
 
@@ -208,6 +210,10 @@ async function buildAab(
 
     if (entryPoint) {
         args.push("--target=" + entryPoint);
+    }
+
+    if (dartDefine) {
+        args.push("--dart-define=" + dartDefine);
     }
 
     if (isVerbose) {


### PR DESCRIPTION
When using build aab, dart-define argument wasn't passed to the command.

This is related to #11 